### PR TITLE
fix: do not take original content-length for data requests

### DIFF
--- a/lib/server/utils.js
+++ b/lib/server/utils.js
@@ -110,7 +110,8 @@ export const getMultipartPayload = async (request) => {
 
   return {
     headers: {
-      ...request.headers,
+      // let axios set content-length automatically
+      ..._.omit(request.headers, 'content-length'),
       ...data.getHeaders(),
     },
     data: data.getBuffer(),


### PR DESCRIPTION
The new headers will be different for multipart/form-data requests, so we can't take the original content-length header and should calculate a new one instead. Axios set it [automatically](https://github.com/axios/axios/blob/master/lib/adapters/http.js#L104-L108) for you if you don't provide it.