### PR TITLE
fix: support multiple files in multipart payload

### DIFF
--- a/lib/server/utils.js
+++ b/lib/server/utils.js
@@ -105,9 +105,15 @@ export const getMultipartPayload = async (request) => {
   });
   await Promise.all(
     Object.entries(files).map(async ([key, value]) => {
+      if (Array.isArray(value)) {
+        return value.map(async (file) => {
+          const buffer = await fs.readFile(file.path);
+          data.append(key, buffer, file.name);
+        });
+      }
       const buffer = await fs.readFile(value.path);
-      data.append(key, buffer, value.name);
-    }),
+      return data.append(key, buffer, value.name);
+    }).flat(),
   );
 
   return {

--- a/tests/createRecordingServer.test.js
+++ b/tests/createRecordingServer.test.js
@@ -46,9 +46,27 @@ describe('recordingServer', () => {
     expect(fse.existsSync(`${RECORDING_DIR}/52a1a7a471169f14486d060fdd85653b-1.json`)).toEqual(true);
   });
 
-  it('proxies multipart/form-data request and record them', async () => {
+  it('proxies multipart/form-data request with a single file per field and record them', async () => {
     const data = new FormData();
     data.append('name', 'Fred');
+    data.append('file', Buffer.from('hello world'), 'hello.txt');
+
+    const response = await axios({
+      url: `${RECORDING_SERVER_URL}/multipart`,
+      method: 'post',
+      data: data.getBuffer(),
+      headers: {
+        ...data.getHeaders(),
+      },
+    });
+    expect(response.data).toEqual({ data: 'post-static--multipart' });
+    expect(fse.existsSync(`${RECORDING_DIR}/7dc4335c8eff6fe9b981290e2fd42b4a-1.json`)).toEqual(true);
+  });
+
+  it('proxies multipart/form-data request with multiple files per field and record them', async () => {
+    const data = new FormData();
+    data.append('files', Buffer.from('hello world 1'), 'hello_1.txt');
+    data.append('files', Buffer.from('hello world 2'), 'hello_2.txt');
 
     const response = await axios({
       url: `${RECORDING_SERVER_URL}/multipart`,


### PR DESCRIPTION
Fixes the error:
```
TypeError: The "path" argument must be type of string or an instance of Buffer or URL. Received undefined.
```

The problem is that the `files` field structure is different for one and multiple files:
```
// for single file
{ files: File {...} }

// for multiple files
{ files: [ File {...}, File {...}] }
```